### PR TITLE
Switch source type from archive to git

### DIFF
--- a/com.github.LongSoft.UEFITool.yml
+++ b/com.github.LongSoft.UEFITool.yml
@@ -23,13 +23,11 @@ modules:
       - cp build/UEFIFind/UEFIFind ${FLATPAK_DEST}/bin/uefifind
       - cp build/UEFITool/UEFITool ${FLATPAK_DEST}/bin/uefitool
     sources:
-      - type: archive
-        url: https://api.github.com/repos/LongSoft/UEFITool/tarball/A63
-        dest-filename: UEFITool.tar.gz
-        sha256: ba80057163906ac2adb352ff3a065518cee5f6497409685a5365d91648206bc9
+      - type: git
+        url: https://github.com/LongSoft/UEFITool
+        tag: A63
+        commit: 3e55a655da54f934b71fa66cfe9923478a586d3e
         x-checker-data:
-          type: json
-          url: https://api.github.com/repos/LongSoft/UEFITool/releases/latest
-          url-query: .tarball_url
-          version-query: .tag_name
+          type: git
+          tag-pattern: "(^A\\d+$)"
           is-main-source: true


### PR DESCRIPTION
GitHub makes no promises that the automatically generated archives will have a consistent checksum. They have changed it twice at this point and it will probably happen again, so migrate to git source type for better reliability.

https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/